### PR TITLE
feat: Allow Lambda function to be VPC bound

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,9 @@ module "lambda" {
     }
   }
 
+  vpc_subnet_ids         = var.lambda_function_vpc_subnet_ids
+  vpc_security_group_ids = var.lambda_function_vpc_security_group_ids
+
   tags = merge(var.tags, var.lambda_function_tags)
 
   depends_on = [aws_cloudwatch_log_group.lambda]

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,18 @@ variable "lambda_function_tags" {
   default     = {}
 }
 
+variable "lambda_function_vpc_subnet_ids" {
+  description = "List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets."
+  type        = list(string)
+  default     = null
+}
+
+variable "lambda_function_vpc_security_group_ids" {
+  description = "List of security group ids when Lambda Function should run in the VPC."
+  type        = list(string)
+  default     = null
+}
+
 variable "sns_topic_tags" {
   description = "Additional tags for the SNS topic"
   type        = map(string)


### PR DESCRIPTION
## Description
Add VPC configuration variables

## Motivation and Context
Depending on the situation, an Organization policy might require that lambda functions are VPC bound. This PR allows to pass VPC configuration down to the underlying lambda module.